### PR TITLE
Bugfix: start in normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ The procedure is the same as above, except:
 * Reload the debugger UI first, then reload the page you just modified. The line "Mobile device connected." should appear in the UI's output pane.
 * You should now be able to evaluate code remotely, set breakpoints, etc.
 
+You can also preprocess your JS code to debug it offline:
+
+* Go to the config inside config folder (you can create a config.local.js file to override default config options).
+* Enable the offline rewriter process setting `config.runOfflineRewriter = true` (you can disable the file server in this mode)
+* Set the output folder where your debugging-enabled scripts will be placed, in the property `config.outputDir`
+* In this mode, you can let Aardwolf to inject the debugging support script in your index file. You can do so by configuring `indexFile`, `whereToInsertAardwolf` and `aardwolfScript` properties in the config file.
+
 
 Debugging processed or minified code
 ----------------------------------------------------------------------------------------------------
@@ -96,6 +103,13 @@ you would need to change it to something like this:
 In most languages, making the modification should be pretty straightforward. PHP's `file_get_contents($url)` and Clojure's `(slurp url)` will handle the change from local paths to URLs transparently. In Scala you can use `io.Source.fromURL(url).mkString`, Ruby has the 'OpenURI' module and in NodeJS you should be able to read remote files using the 'request' module.
 
 Now you should be ready to debug processed code. And since Aardwolf has access to the original files, its UI will display the original, unprocessed code for easier debugging.
+
+
+Solving memory issues
+----------------------------------------------------------------------------------------------------
+
+In some cases in which there are many JavaScript files to debug, you could face a memory issue. If you find that the application is running slowly, you can use `white-list` and `black-list` config properties and choose only the javascript files you want to debug.
+Using one of these properties, only the selected files will be processed by Aardwolf, improving application performance.
 
 
 How it works


### PR DESCRIPTION
Hi again,

Sorry for this, but the pull request I did last time had a bug that impeded the debugger to start in normal mode. It only worked with the new mode I introduced (rewriting all script files to produce a debuggable version). I have solved this so the debugger works in both modes.

Moreover, y have improved the readme file with information about the new mode
